### PR TITLE
Don't force SSO if it's not a production site

### DIFF
--- a/includes/class-force-sso.php
+++ b/includes/class-force-sso.php
@@ -16,6 +16,11 @@ class Force_SSO {
 
 		$force_sso = new static();
 
+		// Bail if it is a staging, development or local site (only force SSO on producion sites).
+		if ( 'production' !== wp_get_environment_type() ) {
+			return;
+		}
+
 		add_filter( 'jetpack_active_modules', array( $force_sso, 'activate_sso' ) );
 		add_action( 'jetpack_module_loaded_sso', array( $force_sso, 'sso_loaded' ) );
 


### PR DESCRIPTION
#### Context
Jetpack doesn't show the SSO login form on staging sites: https://github.com/Automattic/jetpack-production/blob/8cc0ea04cd5563b845ae0d76ca0cadd81504b7dc/modules/sso.php#L169

We are trying to force SSO on development sites, but the SSO form isn't showing up. This causes a login problem.

#### Changes proposed in this Pull Request

* Bail if it is a staging, development, or local site (only force SSO on production sites).

#### Testing instructions

* Install the `team51-force-jetpack-sso` plugin (**trunk branch**) on a non-production site (staging, local, or development). 
* Try to login to the site (the SSO should be forced and the login form shouldn't appear due to the conflict with Jetpack).
* Switch `team51-force-jetpack-sso` to the `fix/issue1 branch` 
* Check the login page again to confirm that SSO is disabled.
* Change the `WP_ENVIRONMENT_TYPE` constant to all different values (`staging`, `development`, `local`, or `production`) to confirm that SSO is only loaded when it's a production site. 

