### PR TITLE
Enable/Disable sso based on env type

### DIFF
--- a/includes/class-force-sso.php
+++ b/includes/class-force-sso.php
@@ -16,11 +16,6 @@ class Force_SSO {
 
 		$force_sso = new static();
 
-		// Bail if it is a staging, development or local site (only force SSO on producion sites).
-		if ( 'production' !== wp_get_environment_type() ) {
-			return;
-		}
-
 		add_filter( 'jetpack_active_modules', array( $force_sso, 'activate_sso' ) );
 		add_action( 'jetpack_module_loaded_sso', array( $force_sso, 'sso_loaded' ) );
 
@@ -37,8 +32,20 @@ class Force_SSO {
 	 * @return array
 	 */
 	public function activate_sso( array $modules ): array {
-		if ( false === array_search( 'sso', $modules, true ) ) {
-			$modules[] = 'sso';
+		$environment_type = wp_get_environment_type();
+
+		// Check if the 'sso' module should be enabled or disabled based on the environment type.
+		if ( 'production' === $environment_type ) {
+			// Add 'sso' module if it's not already enabled.
+			if ( false === array_search( 'sso', $modules, true ) ) {
+				$modules[] = 'sso';
+			}
+		} else {
+			// Disable 'sso' module if it's enabled on a non-production site.
+			$index = array_search( 'sso', $modules, true );
+			if ( false !== $index ) {
+				unset( $modules[ $index ] );
+			}
 		}
 
 		return $modules;

--- a/to51-jetpack-force-sso.php
+++ b/to51-jetpack-force-sso.php
@@ -5,7 +5,7 @@
  * Force "Allow users to log in to this site using WordPress.com accounts".
  * Force "Match accounts using email addresses".
  * Force "Require accounts to use WordPress.com Two-Step Authentication".
- * Version:     1.0.2
+ * Version:     1.0.3
  * Author:      WordPress.com Special Projects Team
  * Author URI:  https://wpspecialprojects.wordpress.com
  * Text Domain: to51-jetpack-force-sso


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable or disable SSO depending on the environment type:
    * Disables SSO (if it's enabled already) on non-production sites
    * Enables SSO on production sites (if it's not enabled already)
* Bump plugin version to 1.0.3

#### Testing instructions

* Install and activate this version of the plugin on a production site and confirm that SSO is required in the login page
* Install and activate this version of the plugin on a non-production site and confirm that SSO isn't required anymore

Mentions #1 

